### PR TITLE
Grade school sorted test now checks against a sorted map.

### DIFF
--- a/grade-school/grade_school_test.clj
+++ b/grade-school/grade_school_test.clj
@@ -33,9 +33,9 @@
   (is (= [] (grade-school/grade db 1))))
 
 (deftest sorted-grade-school
-  (is (= { 3 ["Kyle"]
-           4 ["Christopher" "Jennifer"]
-           6 ["Kareem"] }
+  (is (= (sorted-map 3 ["Kyle"]
+                     4 ["Christopher" "Jennifer"]
+                     6 ["Kareem"] )
          (-> db
              (grade-school/add "Jennifer" 4)
              (grade-school/add "Kareem" 6)


### PR DESCRIPTION
I just opened issue #41 about this. It's a pretty small fix, but the test seems broken to me. Hash maps don't maintain their order, so the comparison fails. This should fix that.