### PR TITLE
Add lein configuration files to exercises.

### DIFF
--- a/accumulate/project.clj
+++ b/accumulate/project.clj
@@ -1,0 +1,6 @@
+(defproject accumulate "0.1.0-SNAPSHOT"
+  :description "accumulate exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/accumulate"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/allergies/project.clj
+++ b/allergies/project.clj
@@ -1,0 +1,6 @@
+(defproject allergies "0.1.0-SNAPSHOT"
+  :description "allergies exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/allergies"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/anagram/project.clj
+++ b/anagram/project.clj
@@ -1,0 +1,6 @@
+(defproject anagram "0.1.0-SNAPSHOT"
+  :description "anagram exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/anagram"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/atbash-cipher/project.clj
+++ b/atbash-cipher/project.clj
@@ -1,0 +1,6 @@
+(defproject atbash-cipher "0.1.0-SNAPSHOT"
+  :description "atbash-cipher exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/atbash-cipher"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/bank-account/project.clj
+++ b/bank-account/project.clj
@@ -1,0 +1,6 @@
+(defproject bank-account "0.1.0-SNAPSHOT"
+  :description "bank-account exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/bank-account"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/beer-song/project.clj
+++ b/beer-song/project.clj
@@ -1,0 +1,6 @@
+(defproject beer-song "0.1.0-SNAPSHOT"
+  :description "beer-song exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/beer-song"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/bin/project.clj
+++ b/bin/project.clj
@@ -1,0 +1,6 @@
+(defproject bin "0.1.0-SNAPSHOT"
+  :description "bin exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/bin"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/binary-search-tree/project.clj
+++ b/binary-search-tree/project.clj
@@ -1,0 +1,6 @@
+(defproject binary-search-tree "0.1.0-SNAPSHOT"
+  :description "binary-search-tree exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/binary-search-tree"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/binary/project.clj
+++ b/binary/project.clj
@@ -1,0 +1,6 @@
+(defproject binary "0.1.0-SNAPSHOT"
+  :description "binary exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/binary"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/bob/project.clj
+++ b/bob/project.clj
@@ -1,0 +1,6 @@
+(defproject bob "0.1.0-SNAPSHOT"
+  :description "bob exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/bob"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/crypto-square/project.clj
+++ b/crypto-square/project.clj
@@ -1,0 +1,6 @@
+(defproject crypto-square "0.1.0-SNAPSHOT"
+  :description "crypto-square exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/crypto-square"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/difference-of-squares/project.clj
+++ b/difference-of-squares/project.clj
@@ -1,0 +1,6 @@
+(defproject difference-of-squares "0.1.0-SNAPSHOT"
+  :description "difference-of-squares exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/difference-of-squares"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/etl/project.clj
+++ b/etl/project.clj
@@ -1,0 +1,6 @@
+(defproject etl "0.1.0-SNAPSHOT"
+  :description "etl exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/etl"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/gigasecond/project.clj
+++ b/gigasecond/project.clj
@@ -1,0 +1,6 @@
+(defproject gigasecond "0.1.0-SNAPSHOT"
+  :description "gigasecond exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/gigasecond"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/grade-school/project.clj
+++ b/grade-school/project.clj
@@ -1,0 +1,6 @@
+(defproject grade-school "0.1.0-SNAPSHOT"
+  :description "grade-school exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/grade-school"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/grains/project.clj
+++ b/grains/project.clj
@@ -1,0 +1,6 @@
+(defproject grains "0.1.0-SNAPSHOT"
+  :description "grains exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/grains"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/hexadecimal/project.clj
+++ b/hexadecimal/project.clj
@@ -1,0 +1,6 @@
+(defproject hexadecimal "0.1.0-SNAPSHOT"
+  :description "hexadecimal exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/hexadecimal"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/kindergarten-garden/project.clj
+++ b/kindergarten-garden/project.clj
@@ -1,0 +1,6 @@
+(defproject kindergarten-garden "0.1.0-SNAPSHOT"
+  :description "kindergarten-garden exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/kindergarten-garden"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/largest-series-product/project.clj
+++ b/largest-series-product/project.clj
@@ -1,0 +1,6 @@
+(defproject largest-series-product "0.1.0-SNAPSHOT"
+  :description "largest-series-product exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/largest-series-product"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/leap/project.clj
+++ b/leap/project.clj
@@ -1,0 +1,6 @@
+(defproject leap "0.1.0-SNAPSHOT"
+  :description "leap exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/leap"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/meetup/project.clj
+++ b/meetup/project.clj
@@ -1,0 +1,6 @@
+(defproject meetup "0.1.0-SNAPSHOT"
+  :description "meetup exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/meetup"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/nucleotide-count/project.clj
+++ b/nucleotide-count/project.clj
@@ -1,0 +1,6 @@
+(defproject nucleotide-count "0.1.0-SNAPSHOT"
+  :description "nucleotide-count exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/nucleotide-count"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/phone-number/project.clj
+++ b/phone-number/project.clj
@@ -1,0 +1,6 @@
+(defproject phone-number "0.1.0-SNAPSHOT"
+  :description "phone-number exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/phone-number"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/point-mutations/project.clj
+++ b/point-mutations/project.clj
@@ -1,0 +1,6 @@
+(defproject point-mutations "0.1.0-SNAPSHOT"
+  :description "point-mutations exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/point-mutations"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/prime-factors/project.clj
+++ b/prime-factors/project.clj
@@ -1,0 +1,6 @@
+(defproject prime-factors "0.1.0-SNAPSHOT"
+  :description "prime-factors exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/prime-factors"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/queen-attack/project.clj
+++ b/queen-attack/project.clj
@@ -1,0 +1,6 @@
+(defproject queen-attack "0.1.0-SNAPSHOT"
+  :description "queen-attack exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/queen-attack"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/raindrops/project.clj
+++ b/raindrops/project.clj
@@ -1,0 +1,6 @@
+(defproject raindrops "0.1.0-SNAPSHOT"
+  :description "raindrops exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/raindrops"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/rna-transcription/project.clj
+++ b/rna-transcription/project.clj
@@ -1,0 +1,6 @@
+(defproject rna-transcription "0.1.0-SNAPSHOT"
+  :description "rna-transcription exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/rna-transcription"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/robot-name/project.clj
+++ b/robot-name/project.clj
@@ -1,0 +1,6 @@
+(defproject robot-name "0.1.0-SNAPSHOT"
+  :description "robot-name exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/robot-name"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/robot-simulator/project.clj
+++ b/robot-simulator/project.clj
@@ -1,0 +1,6 @@
+(defproject robot-simulator "0.1.0-SNAPSHOT"
+  :description "robot-simulator exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/robot-simulator"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/roman-numerals/project.clj
+++ b/roman-numerals/project.clj
@@ -1,0 +1,6 @@
+(defproject roman-numerals "0.1.0-SNAPSHOT"
+  :description "roman-numerals exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/roman-numerals"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/scrabble-score/project.clj
+++ b/scrabble-score/project.clj
@@ -1,0 +1,6 @@
+(defproject scrabble-score "0.1.0-SNAPSHOT"
+  :description "scrabble-score exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/scrabble-score"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/space-age/project.clj
+++ b/space-age/project.clj
@@ -1,0 +1,6 @@
+(defproject space-age "0.1.0-SNAPSHOT"
+  :description "space-age exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/space-age"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/triangle/project.clj
+++ b/triangle/project.clj
@@ -1,0 +1,6 @@
+(defproject triangle "0.1.0-SNAPSHOT"
+  :description "triangle exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/triangle"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])

--- a/word-count/project.clj
+++ b/word-count/project.clj
@@ -1,0 +1,6 @@
+(defproject word-count "0.1.0-SNAPSHOT"
+  :description "word-count exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/word-count"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.6.0"]])


### PR DESCRIPTION
By default lein sets source-path and test-path to "src" and "tests" 
respectively.  Therefore lein will require such folders to be set in order to
load any of the exercises such as are given in the clojure help section:

```
  To open a REPL using Leiningen change to the directory containing the
 exercise and run:

  $ lein repl

  Once you are ready to work on an exercise and have created a file to
 hold your solution (such as bob.clj) you can run the tests using
 load-file:

  (load-file "bob_test.clj")
```
But these instructions fail because lein doesn't know where to look for the
files.

This commit adds a lein config file for each of the exercises that forces lein
to look in the current directory for tests and source files.

This also has the added benefit that users that use vim-Fireplace will be able
to evaluate the code from within their editors.