### PR TITLE
Remove lein config file from bin folder.

### DIFF
--- a/bin/project.clj
+++ b/bin/project.clj
@@ -1,6 +1,0 @@
-(defproject bin "0.1.0-SNAPSHOT"
-  :description "bin exercise."
-  :url "https://github.com/exercism/xclojure/tree/master/bin"
-  :source-paths [""]
-  :test-paths [""]
-  :dependencies [[org.clojure/clojure "1.6.0"]])


### PR DESCRIPTION
The bin folder is not an exercise.  This commit removes a lein
configuration file that was incorrectly merged in by a previous pull
request.