### PR TITLE
resolve warnings; use isLetter for readability

### DIFF
--- a/bob/example.clj
+++ b/bob/example.clj
@@ -5,8 +5,7 @@
 
 (defn- question?   [msg] (= \? (last msg)))
 
-(defn- has-letter? [msg] (some #(or (Character/isUpperCase %)
-                                    (Character/isLowerCase %)) msg))
+(defn- has-letter? [msg] (some #(Character/isLetter (int %)) msg))
 
 (defn- shouting?   [msg] (and (= msg (str/upper-case msg))
                               (has-letter? msg)))


### PR DESCRIPTION
The warnings were on Leiningen 2.5.1 on Java 1.8.0_45 OpenJDK 64-Bit Server VM:

call to static method isUpperCase on java.lang.Character can't be resolved (argument types: unknown).

call to static method isLowerCase on java.lang.Character can't be resolved (argument types: unknown).