### PR TITLE
Update allergies

### DIFF
--- a/allergies/allergies_test.clj
+++ b/allergies/allergies_test.clj
@@ -4,41 +4,45 @@
 (load-file "allergies.clj")
 
 (deftest no-allergies-at-all
-  (is (= [] (allergies/list 0))))
+  (is (= [] (allergies/allergies 0))))
 
 (deftest allergic-to-just-eggs
-  (is (= ["eggs"] (allergies/list 1))))
+  (is (= [:eggs] (allergies/allergies 1))))
 
 (deftest allergic-to-just-peanuts
-  (is (= ["peanuts"] (allergies/list 2))))
+  (is (= [:peanuts] (allergies/allergies 2))))
 
 (deftest allergic-to-just-strawberries
-  (is (= ["strawberries"] (allergies/list 8))))
+  (is (= [:strawberries] (allergies/allergies 8))))
 
 (deftest allergic-to-eggs-and-peanuts
-  (is (= ["eggs", "peanuts"] (allergies/list 3))))
+  (is (= [:eggs :peanuts] (allergies/allergies 3))))
 
 (deftest allergic-to-more-than-eggs-but-not-peanuts
-  (is (= ["eggs", "shellfish"] (allergies/list 5))))
+  (is (= [:eggs :shellfish] (allergies/allergies 5))))
 
 (deftest allergic-to-lots-of-stuff
-  (is (= ["strawberries", "tomatoes", "chocolate", "pollen", "cats"] (allergies/list 248))))
+  (is (= [:strawberries :tomatoes :chocolate :pollen :cats]
+         (allergies/allergies 248))))
 
 (deftest allergic-to-everything
-  (is (= ["eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"] (allergies/list 255))))
+  (is (= [:eggs :peanuts :shellfish :strawberries
+          :tomatoes :chocolate :pollen :cats]
+         (allergies/allergies 255))))
 
 (deftest no-allergies-means-not-allergic
-  (is (not (allergies/allergic_to? 0 "peanuts")))
-  (is (not (allergies/allergic_to? 0 "cats")))
-  (is (not (allergies/allergic_to? 0 "strawberries"))))
+  (is (not (allergies/allergic-to? 0 :peanuts)))
+  (is (not (allergies/allergic-to? 0 :cats)))
+  (is (not (allergies/allergic-to? 0 :strawberries))))
 
 (deftest is-allergic-to-eggs
-  (is (allergies/allergic_to? 1 "eggs")))
+  (is (allergies/allergic-to? 1 :eggs)))
 
 (deftest allergic-to-eggs-in-addition-to-other-stuff
-  (is (allergies/allergic_to? 5 "eggs")))
+  (is (allergies/allergic-to? 5 :eggs)))
 
 (deftest ignore-non-allergen-score-parts
-  (is (= ["eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"] (allergies/list 509))))
+  (is (= [:eggs :shellfish :strawberries :tomatoes :chocolate :pollen :cats]
+         (allergies/allergies 509))))
 
 (run-tests)

--- a/allergies/example.clj
+++ b/allergies/example.clj
@@ -1,25 +1,24 @@
 (ns allergies)
 
 (def ^:private allergens
-  ["eggs" "peanuts" "shellfish" "strawberries" "tomatoes" "chocolate" "pollen" "cats"])
+  [:eggs :peanuts :shellfish :strawberries :tomatoes :chocolate :pollen :cats])
 
 (defn- flagged?
   [flags index]
-  (> (bit-and
-       (bit-shift-right flags index) 1)
-     0))
+  (-> (bit-shift-right flags index)
+      (bit-and 1)
+      (pos?)))
 
-(defn list
-  "given an 8-bit bitmap of flags, return the list of matching allergens"
+(defn allergies
+  "Given an 8-bit bitmap of flags, return the list of matching allergens."
   [flags]
-  (mapv last
-    (filter
-      (fn [[index allergen]]
-        (flagged? flags index))
-      (map-indexed vector allergens))))
+  (keep-indexed (fn [index allergen]
+                  (when (flagged? flags index)
+                    allergen))
+                allergens))
 
-(defn allergic_to?
-  "given an 8-bit bitmap of flags and an allergen, return a boolean indicating whether or not the patient is allergic to the given allergen"
+(defn allergic-to?
+  "Given an 8-bit bitmap of flags and an allergen, return a boolean
+  indicating whether or not the patient is allergic to the given allergen."
   [flags allergen]
-  (some #(= allergen %1) (list flags)))
-
+  (some #{allergen} (allergies flags)))


### PR DESCRIPTION
See #68 for context.

=====

Per #68, use `keep-indexed`. (+6 squashed commits)
Squashed commits:
[ec532a5] Update allergies

Per #68, use `(some #{x} xs)` idiom.
[b732b29] Update allergies

Use `->` threading macro in `flagged?`.
[3a5bf71] Update allergies

Format docstrings.
[fb046da] Update allergies

Per #68, rename `list` to `allergies`.
[0b43f40] Update allergies

Per #68, rename `allergic_to?` to `allergic-to?`.
[6a25b57] Update allergies

Per #68, use keywords instead of strings.