### PR TITLE
Allows asserts in addition to exceptions.

### DIFF
--- a/nucleotide-count/nucleotide_count_test.clj
+++ b/nucleotide-count/nucleotide_count_test.clj
@@ -21,7 +21,7 @@
   (is (= 1 (nucleotide-count/count \T "GGGGGTAACCCGG"))))
 
 (deftest validates-nucleotides
-    (is (thrown-with-msg? Throwable #"invalid nucleotide" (nucleotide-count/count \X "GACT"))))
+  (is (thrown-with-msg? Throwable #"invalid nucleotide" (nucleotide-count/count \X "GACT"))))
 
 (deftest counts-all-nucleotides
   (let [s "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"]

--- a/nucleotide-count/nucleotide_count_test.clj
+++ b/nucleotide-count/nucleotide_count_test.clj
@@ -21,7 +21,7 @@
   (is (= 1 (nucleotide-count/count \T "GGGGGTAACCCGG"))))
 
 (deftest validates-nucleotides
-  (is (thrown-with-msg? Throwable #"invalid nucleotide" (nucleotide-count/count \X "GACT"))))
+  (is (thrown? Throwable (nucleotide-count/count \X "GACT"))))
 
 (deftest counts-all-nucleotides
   (let [s "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"]

--- a/nucleotide-count/nucleotide_count_test.clj
+++ b/nucleotide-count/nucleotide_count_test.clj
@@ -21,7 +21,7 @@
   (is (= 1 (nucleotide-count/count \T "GGGGGTAACCCGG"))))
 
 (deftest validates-nucleotides
-  (is (thrown-with-msg? Exception #"invalid nucleotide" (nucleotide-count/count \X "GACT"))))
+    (is (thrown-with-msg? Throwable #"invalid nucleotide" (nucleotide-count/count \X "GACT"))))
 
 (deftest counts-all-nucleotides
   (let [s "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"]


### PR DESCRIPTION
This keeps backwards compatibility with existing solutions for nucleotide-count.