### PR TITLE
Add binary-search exercise

### DIFF
--- a/binary-search/binary_search_test.clj
+++ b/binary-search/binary_search_test.clj
@@ -1,0 +1,45 @@
+(ns binary-search-test
+  (:require [clojure.test :refer :all]))
+
+(load-file "binary_search.clj")
+
+(def short-vector [1, 3, 4, 6, 8, 9, 11])
+(def unsorted-vector [2, 1, 4, 3, 6])
+(def large-vector [1, 3, 5, 8, 13, 21, 34, 55, 89])
+(def even-length-vector [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377])
+
+(deftest it-finds-position-of-middle-item
+  (is (= 3 (binary-search/middle short-vector))))
+
+(deftest searches-a-singleton
+  (is (= 0 (binary-search/search-for 4 [4]))))
+
+(deftest throws-exception-when-list-is-not-sorted
+  (is (thrown? Throwable (binary-search/search-for 5 unsorted-vector))))
+
+(deftest it-finds-position-of-search-data
+  (is (= 5 (binary-search/search-for 9 short-vector))))
+
+(deftest it-finds-position-in-a-larger-list
+  (is (= 1 (binary-search/search-for 3 large-vector))))
+
+(deftest it-finds-position-in-a-larger-list-again
+  (is (= 7 (binary-search/search-for 55 large-vector))))
+
+(deftest it-finds-correct-position-in-a-list-with-an-even-number-of-elements
+  (is (= 5 (binary-search/search-for 21 even-length-vector))))
+
+(deftest it-finds-correct-position-in-a-list-with-an-even-number-of-elements-again
+  (is (= 6 (binary-search/search-for 34 even-length-vector))))
+
+(deftest it-works-on-lists
+  (is (= 7 (binary-search/search-for 7 (range 10)))))
+
+(deftest it-works-on-lists-again
+  (is (= 4 (binary-search/search-for 3 '(-3 -2 0 1 3 4)))))
+
+(deftest throws-exception-when-element-not-found
+  (is (thrown? Throwable (binary-search/search-for 20 short-vector))))
+
+(run-tests)
+

--- a/binary-search/binary_search_test.clj
+++ b/binary-search/binary_search_test.clj
@@ -4,8 +4,11 @@
 (load-file "binary_search.clj")
 
 (def short-vector [1, 3, 4, 6, 8, 9, 11])
+
 (def unsorted-vector [2, 1, 4, 3, 6])
+
 (def large-vector [1, 3, 5, 8, 13, 21, 34, 55, 89])
+
 (def even-length-vector [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377])
 
 (deftest it-finds-position-of-middle-item

--- a/binary-search/example.clj
+++ b/binary-search/example.clj
@@ -1,0 +1,18 @@
+(ns binary-search)
+
+(defn middle
+  [alist]
+  (-> alist
+      (count)
+       (quot 2)))
+
+(defn search-for
+  [elem alist]
+  (assert (apply <= alist) "Input list must be sorted")
+  (let [middle (middle alist)
+        cur-elem (nth alist middle)]
+    (cond
+      (= cur-elem elem) middle
+      (or (= middle (count alist)) (zero? middle)) (throw (Exception. (format "%s not found in list" elem)))
+      (< cur-elem elem) (+ middle (search-for elem (drop middle alist)))
+      (> cur-elem elem) (search-for elem (take middle alist)))))

--- a/binary-search/example.clj
+++ b/binary-search/example.clj
@@ -1,10 +1,7 @@
 (ns binary-search)
 
-(defn middle
-  [alist]
-  (-> alist
-      (count)
-       (quot 2)))
+(defn middle [alist]
+  (-> alist (count) (quot 2)))
 
 (defn search-for
   [elem alist]

--- a/binary-search/example.clj
+++ b/binary-search/example.clj
@@ -5,7 +5,7 @@
 
 (defn search-for
   [elem alist]
-  (assert (apply <= alist) "Input list must be sorted")
+  {:pre [(apply <= alist)]}
   (let [middle (middle alist)
         cur-elem (nth alist middle)]
     (cond

--- a/binary-search/project.clj
+++ b/binary-search/project.clj
@@ -1,0 +1,6 @@
+(defproject binary-search "0.1.0-SNAPSHOT"
+  :description "binary-search exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/binary-search"
+  :source-paths [""]
+  :test-paths [""]
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/config.json
+++ b/config.json
@@ -16,6 +16,7 @@
     "robot-name",
     "leap",
     "etl",
+    "binary-search",
     "meetup",
     "space-age",
     "grains",


### PR DESCRIPTION
This adds the binary-search exercise to the clojure track. It includes
most of the tests from the ruby version as well as a couple of extras to
ensure the search works on lists as well as vectors. It also adds it to the
config.json in the first half of the clojure track.