### PR TITLE
Set sudo to false in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: bash
+sudo: false
 
 script:
   - bin/fetch-configlet


### PR DESCRIPTION
Setting sudo to false in the travis config will allow the travis tests
to run in travis' container based infrastructure and have faster start
times.