### PR TITLE
Use thrown-with-msg? in error case tests

### DIFF
--- a/binary-search/binary_search_test.clj
+++ b/binary-search/binary_search_test.clj
@@ -18,7 +18,7 @@
   (is (= 0 (binary-search/search-for 4 [4]))))
 
 (deftest throws-exception-when-list-is-not-sorted
-  (is (thrown? Throwable (binary-search/search-for 5 unsorted-vector))))
+  (is (thrown-with-msg? Throwable #"must be sorted" (binary-search/search-for 5 unsorted-vector))))
 
 (deftest it-finds-position-of-search-data
   (is (= 5 (binary-search/search-for 9 short-vector))))
@@ -42,7 +42,7 @@
   (is (= 4 (binary-search/search-for 3 '(-3 -2 0 1 3 4)))))
 
 (deftest throws-exception-when-element-not-found
-  (is (thrown? Throwable (binary-search/search-for 20 short-vector))))
+  (is (thrown-with-msg? Throwable #"not found" (binary-search/search-for 20 short-vector))))
 
 (run-tests)
 

--- a/binary-search/example.clj
+++ b/binary-search/example.clj
@@ -5,7 +5,8 @@
 
 (defn search-for
   [elem alist]
-  {:pre [(apply <= alist)]}
+  {:pre [(or (apply <= alist)
+             (throw (Exception. "Collection must be sorted")))]}
   (let [middle (middle alist)
         cur-elem (nth alist middle)]
     (cond


### PR DESCRIPTION
If the tests for error cases care only that a Throwable is thrown, there is potential for false passes to occur.

For example, if the implementation of `binary-search/search-for` throws an IndexOutOfBoundsException for some input, the test will pass, even though there's actually just a bug in `binary-search/search-for`.

By checking for some message, we can be a little more confident that the tests are passing only for the correct exceptions.

Also, updated example.clj to pass the modified tests again.