### PR TITLE
Update largest-series-product per #49

### DIFF
--- a/largest-series-product/example.clj
+++ b/largest-series-product/example.clj
@@ -2,11 +2,10 @@
 
 (defn digits [ds] (map #(Character/digit % 10) ds))
 
-(defn slices [n ds]
-  (partition n 1 (digits ds)))
+(defn slices [n ds] (partition n 1 (digits ds)))
 
 (defn largest-product [size ds]
-  (if
-    (or (empty? ds) (> size (count ds))) 1
-    (apply max (map #(apply * %) (slices size ds)))))
-
+  (cond
+    (empty? ds)         (throw (Exception. "Series must not be empty."))
+    (> size (count ds)) 1
+    :else               (apply max (map (partial apply *) (slices size ds)))))

--- a/largest-series-product/largest_series_product_test.clj
+++ b/largest-series-product/largest_series_product_test.clj
@@ -1,13 +1,15 @@
 (ns largest-series-product-test
-  (:require [clojure.test :refer :all]))
+  (:require [clojure.test :refer [deftest is]]))
 
-(deftest largest_series_tests
+(deftest largest-series-tests
   (is (= (range 0 10) (largest-series-product/digits "0123456789")))
   (is (= (range 9 -1 -1) (largest-series-product/digits "9876543210")))
   (is (= (range 8 3 -1) (largest-series-product/digits "87654")))
   (is (= [9 3 6 9 2 3 4 6 8] (largest-series-product/digits "936923468")))
-  (is (= [[9 8] [8 2] [2 7] [7 3] [3 4] [4 6] [6 3]] (largest-series-product/slices 2 "98273463")))
-  (is (= [[9 8 2] [8 2 3] [2 3 4] [3 4 7]] (largest-series-product/slices 3 "982347")))
+  (is (= [[9 8] [8 2] [2 7] [7 3] [3 4] [4 6] [6 3]]
+         (largest-series-product/slices 2 "98273463")))
+  (is (= [[9 8 2] [8 2 3] [2 3 4] [3 4 7]]
+         (largest-series-product/slices 3 "982347")))
   (is (= 72 (largest-series-product/largest-product 2 "0123456789")))
   (is (= 2 (largest-series-product/largest-product 2 "12")))
   (is (= 9 (largest-series-product/largest-product 2 "19")))
@@ -15,9 +17,14 @@
   (is (= 504 (largest-series-product/largest-product 3 "0123456789")))
   (is (= 270 (largest-series-product/largest-product 3 "1027839564")))
   (is (= 15120 (largest-series-product/largest-product 5 "0123456789")))
-  (is (= 23520 (largest-series-product/largest-product 6 "73167176531330624919225119674426574742355349194934")))
-  (is (= 28350 ( largest-series-product/largest-product 6 "52677741234314237566414902593461595376319419139427")))
-  (is (= 1 (largest-series-product/largest-product 0 "")))
+  (is (= 23520
+         (let [ds "73167176531330624919225119674426574742355349194934"]
+           (largest-series-product/largest-product 6 ds))))
+  (is (= 28350
+         (let [ds "52677741234314237566414902593461595376319419139427"]
+           (largest-series-product/largest-product 6 ds))))
+  (is (thrown-with-msg? Throwable #"empty"
+        (largest-series-product/largest-product 0 "")))
   ;; unlike the Ruby implementation no error is expected for too small input
   (is (= 1 (largest-series-product/largest-product 4 "123")))
   ;; edge case :)


### PR DESCRIPTION
Clean up whitespace/line width and throw (and test for) an `Exception` when the given digit series is empty.