### PR TITLE
Add (= :illogical (triangle/type 2 4 2)) test

### DIFF
--- a/triangle/src/example.clj
+++ b/triangle/src/example.clj
@@ -1,4 +1,5 @@
-(ns triangle)
+(ns triangle
+  (:refer-clojure :exclude [type]))
 
 (defn- invalid-sides [a b c]
   (let [[a b c] (sort [a b c])]
@@ -6,11 +7,9 @@
         (>= c (+ a b)))))
 
 (defn type [a b c]
-  (let [unique-sides (partition-by identity (sort [a b c]))
-        unique-side-count (count unique-sides)
-        invalid (invalid-sides a b c)]
-    (cond
-      invalid                 :illogical
-      (= 1 unique-side-count) :equilateral
-      (= 2 unique-side-count) :isosceles
-      :else                   :scalene)))
+  (if (invalid-sides a b c)
+    :illogical
+    (case (count (hash-set a b c))
+      1 :equilateral
+      2 :isosceles
+      :scalene)))

--- a/triangle/test/triangle_test.clj
+++ b/triangle/test/triangle_test.clj
@@ -4,15 +4,24 @@
 
 (deftest equilateral-1
   (is (= :equilateral (triangle/type 2 2 2))))
+
 (deftest equilateral-2
   (is (= :equilateral (triangle/type 10 10 10))))
+
 (deftest isosceles-1
   (is (= :isosceles (triangle/type 3 4 4))))
+
 (deftest isosceles-2
   (is (= :isosceles (triangle/type 4 3 4))))
+
 (deftest scalene
   (is (= :scalene (triangle/type 3 4 5))))
+
 (deftest invalid-1
   (is (= :illogical (triangle/type 1 1 50))))
+
 (deftest invalid-2
   (is (= :illogical (triangle/type 1 2 1))))
+
+(deftest invalid-3
+  (is (= :illogical (triangle/type 2 4 2))))


### PR DESCRIPTION
This PR will fix #95.

-----

Use empty lines between top-level forms.

Exclude `#'clojure.core/type` to avoid collision.

Make `#'triangle/type` point-free and ~2x faster.

If the sides are invalid, there's no need to compute the set. Unlike `cond`, `case` does a constant-time dispatch. Since we're effectively performing case analysis on `1` and `2` (constants), we might as well use `case` instead of `cond`. The point-free-ness of this change is both a matter of personal taste and "lazy" evaluation, i.e. don't compute unnecessary values.

The [previous solution]'s use of:

```clojure
(partition-by identity (sort [a b c]))
```

... is unnecessarily complex.

```clojure
(hash-set a b c)
```

... [gets the job done] more simply.

[1]: https://github.com/bbatsov/clojure-style-guide#empty-lines-between-top-level-forms
[previous solution]: https://github.com/exercism/xclojure/blob/a995a753a6ae5eafa6d874521618c66b3b84330b/triangle/src/example.clj#L9
[gets the job done]: https://github.com/exercism/xclojure/blob/ebb05fe9981fe87a7f250bad3227aebdac0b74e2/triangle/src/example.clj#L12