### PR TITLE
largest-series-product: Do not test digits/slices

### DIFF
--- a/exercises/largest-series-product/src/example.clj
+++ b/exercises/largest-series-product/src/example.clj
@@ -1,8 +1,8 @@
 (ns largest-series-product)
 
-(defn digits [ds] (map #(Character/digit % 10) ds))
+(defn- digits [ds] (map #(Character/digit % 10) ds))
 
-(defn slices [n ds] (partition n 1 (digits ds)))
+(defn- slices [n ds] (partition n 1 (digits ds)))
 
 (defn largest-product [size ds]
   (cond

--- a/exercises/largest-series-product/test/largest_series_product_test.clj
+++ b/exercises/largest-series-product/test/largest_series_product_test.clj
@@ -3,14 +3,6 @@
             [largest-series-product :as lsp]))
 
 (deftest largest-series-tests
-  (is (= (range 0 10) (lsp/digits "0123456789")))
-  (is (= (range 9 -1 -1) (lsp/digits "9876543210")))
-  (is (= (range 8 3 -1) (lsp/digits "87654")))
-  (is (= [9 3 6 9 2 3 4 6 8] (lsp/digits "936923468")))
-  (is (= [[9 8] [8 2] [2 7] [7 3] [3 4] [4 6] [6 3]]
-         (lsp/slices 2 "98273463")))
-  (is (= [[9 8 2] [8 2 3] [2 3 4] [3 4 7]]
-         (lsp/slices 3 "982347")))
   (is (= 72 (lsp/largest-product 2 "0123456789")))
   (is (= 2 (lsp/largest-product 2 "12")))
   (is (= 9 (lsp/largest-product 2 "19")))


### PR DESCRIPTION
The digits and slices functions are internal implementation details and
thus the test case for the largest-series-product problem should not be
concerned with testing them. The series tests could potentially be moved
to the series exercise (which would have to be a new addition to this track)

Their presence may cause students to falsely think that their solution
has to use these two functions, instead of the alternative
implementation of only iterating through the digits once.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the digits and slices tests), then consider
including a hints file and/or directory in the largest-series-product
directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192