### PR TITLE
Fix false positive when using atoms.

### DIFF
--- a/exercises/robot-name/test/robot_name_test.clj
+++ b/exercises/robot-name/test/robot_name_test.clj
@@ -13,7 +13,9 @@
   (is (= (robot-name/robot-name robbie) (robot-name/robot-name robbie))))
 
 (deftest different-robots-have-different-names
-  (is (not (= (robot-name/robot-name clutz) (robot-name/robot-name robbie)))))
+  (let [robbie (robot-name/robot)
+        clutz (robot-name/robot)]
+    (is (not (= (robot-name/robot-name clutz) (robot-name/robot-name robbie))))))
 
 (def original-name (robot-name/robot-name robbie))
 (robot-name/reset-name robbie)


### PR DESCRIPTION
Ref #114

Use the lexical scope to prevent false positive.