### PR TITLE
Re-add bank account

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,6 +33,7 @@
     "octal",
     "strain",
     "atbash-cipher",
+    "bank-account",
     "crypto-square",
     "pascals-triangle",
     "sum-of-multiples",
@@ -64,6 +65,5 @@
     "img"
   ],
   "foregone": [
-    "bank-account"
   ]
 }

--- a/exercises/bank-account/project.clj
+++ b/exercises/bank-account/project.clj
@@ -1,0 +1,4 @@
+(defproject bank-account "0.1.0-SNAPSHOT"
+  :description "bank-account exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/exercises/bank-account"
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/bank-account/src/example.clj
+++ b/exercises/bank-account/src/example.clj
@@ -1,0 +1,17 @@
+(ns bank-account)
+
+(defn open-account []
+  (ref 0))
+
+(defn close-account [account]
+  (dosync
+    (ref-set account nil)))
+
+(defn get-balance [account]
+  (dosync
+    @account))
+
+(defn update-balance [account amt]
+  (dosync
+    (alter account + amt)))
+

--- a/exercises/bank-account/test/bank_account_test.clj
+++ b/exercises/bank-account/test/bank_account_test.clj
@@ -11,9 +11,8 @@
 
 (deftest initial-account-state
   (testing "Accounts are opened with a balance of 0"
-    (is (= 0 (->
-                (bank-account/open-account)
-                (bank-account/get-balance))))))
+    (is (= 0 (-> (bank-account/open-account)
+                 (bank-account/get-balance))))))
 
 (deftest increment-and-get-balance
   (testing "Adding money to the account works"

--- a/exercises/bank-account/test/bank_account_test.clj
+++ b/exercises/bank-account/test/bank_account_test.clj
@@ -1,0 +1,45 @@
+(ns bank-account-test
+  (:require
+    [clojure.test :refer [deftest testing is use-fixtures]]
+    [bank-account]))
+
+(defn shutdown-agents-fixture [f]
+  (f)
+  (shutdown-agents))
+
+(use-fixtures :once shutdown-agents-fixture)
+
+(deftest initial-account-state
+  (testing "Accounts are opened with a balance of 0"
+    (is (= 0 (->
+                (bank-account/open-account)
+                (bank-account/get-balance))))))
+
+(deftest increment-and-get-balance
+  (testing "Adding money to the account works"
+    (let [account (bank-account/open-account)]
+      (is (= 0 (bank-account/get-balance account)))
+      (bank-account/update-balance account 10)
+      (is (= 10 (bank-account/get-balance account))))))
+
+(deftest increment-decrement-and-get-balance
+  (testing "Taking money out of the account works"
+    (let [account (bank-account/open-account)]
+      (is (= 0 (bank-account/get-balance account)))
+      (bank-account/update-balance account 10)
+      (is (= 10 (bank-account/get-balance account)))
+      (bank-account/update-balance account -10)
+      (is (= 0 (bank-account/get-balance account))))))
+
+(deftest closed-accounts-are-nil
+  (testing "Closing an account makes it nil"
+    (let [account (bank-account/open-account)]
+      (bank-account/close-account account)
+      (is (nil? (bank-account/get-balance account))))))
+
+(deftest check-concurrent-access
+  (testing "The account can handle parallel access"
+    (let [account (bank-account/open-account)
+          add-10 #(bank-account/update-balance account 10)]
+      (doall (pcalls add-10 add-10 add-10 add-10 add-10))
+      (is (= 50 (bank-account/get-balance account))))))


### PR DESCRIPTION
This PR re-adds the previous bank-account exercise with an updated
test suite. The previous test suite had a call to (shutdown-agents)
outside of a function body, which caused it to get called before all
tests had executed. This version of the test suite uses a fixture to
ensure that the (shutdown-agents) call happens *after* all tests have
executed.