### PR TITLE
Add test to robot-name to make sure name in reset isn't hard-coded (fixes #148)

### DIFF
--- a/exercises/robot-name/test/robot_name_test.clj
+++ b/exercises/robot-name/test/robot_name_test.clj
@@ -2,28 +2,30 @@
   (:require [clojure.test :refer [deftest is testing]]
             robot-name))
 
-(def ^:private robbie (robot-name/robot))
-(def ^:private clutz  (robot-name/robot))
-
 (deftest robot-name
-  (testing "robot-name"
-    (is (re-seq #"[A-Z]{2}\d{3}" (robot-name/robot-name robbie))
-        "name matches expected pattern")
-    (is (= (robot-name/robot-name robbie) (robot-name/robot-name robbie))
-        "name is persistent")
-    (is (not= (robot-name/robot-name clutz) (robot-name/robot-name robbie))
-        "different robots have different names")))
+  (let [a-robot (robot-name/robot)
+        its-name (robot-name/robot-name a-robot)]
+    (testing "robot-name"
+      (is (re-seq #"[A-Z]{2}\d{3}" its-name)
+          "name matches expected pattern")
+      (is (= its-name (robot-name/robot-name a-robot))
+          "name doesn't change until you reset it")
+      (is (not= its-name (-> (robot-name/robot) robot-name/robot-name))
+          "different robots have different names"))))
 
 (deftest reset-name
-  (testing "reset-name"
-    (let [original-name (robot-name/robot-name robbie)]
-      (robot-name/reset-name robbie)
-      (is (re-seq #"[A-Z]{2}\d{3}" (robot-name/robot-name robbie))
+  (let [a-robot (robot-name/robot)
+        its-original-name (robot-name/robot-name a-robot)
+        its-new-name (do (robot-name/reset-name a-robot)
+                         (robot-name/robot-name a-robot))]
+
+    (testing "reset-name"
+      (is (re-seq #"[A-Z]{2}\d{3}" its-new-name)
           "new name matches expected pattern")
-      (is (= (robot-name/robot-name robbie) (robot-name/robot-name robbie))
-          "new name is persistent")
-      (is (not= original-name (robot-name/robot-name robbie))
+      (is (not= its-original-name its-new-name)
           "new name is different from old name")
-      (is (not= (robot-name/robot-name robbie)
-                (-> robbie robot-name/reset-name robot-name/robot-name))
-          "new name is different each time"))))
+      (is (= its-new-name (robot-name/robot-name a-robot))
+          "new name doesn't change until you reset it")
+      (is (not= its-new-name (do (robot-name/reset-name a-robot)
+                                 (robot-name/robot-name a-robot)))
+          "new names are different each time"))))

--- a/exercises/robot-name/test/robot_name_test.clj
+++ b/exercises/robot-name/test/robot_name_test.clj
@@ -23,4 +23,7 @@
       (is (= (robot-name/robot-name robbie) (robot-name/robot-name robbie))
           "new name is persistent")
       (is (not= original-name (robot-name/robot-name robbie))
-          "new name is different from old name"))))
+          "new name is different from old name")
+      (is (not= (robot-name/robot-name robbie)
+                (-> robbie robot-name/reset-name robot-name/robot-name))
+          "new name is different each time"))))


### PR DESCRIPTION
As per [this discussion](https://github.com/exercism/xclojure/issues/148), the tests didn't prevent you from hard-coding the new name in the `reset-name` function. This adds a new test to make sure you don't do that.
