### PR TITLE
Simplify example implementation of robot-name

### DIFF
--- a/exercises/robot-name/src/example.clj
+++ b/exercises/robot-name/src/example.clj
@@ -7,10 +7,10 @@
        (+ 100 (.nextInt random 899))))
 
 (defn robot []
-  {:name (atom (generate-name))})
+  (atom {:name (generate-name)}))
 
 (defn robot-name [robot]
-  @(:name robot))
+  (:name @robot))
 
 (defn reset-name [robot]
-  (reset! (:name robot) (generate-name)))
+  (swap! robot assoc :name (generate-name)))

--- a/exercises/robot-name/src/example.clj
+++ b/exercises/robot-name/src/example.clj
@@ -1,19 +1,16 @@
 (ns robot-name)
 
-(defn robot []
-  {:name (atom "")})
-
-(def random (java.util.Random.))
-(def letters (map char (range 65 91)))
-(defn generate-name []
+(def ^:private random (java.util.Random.))
+(def ^:private letters (map char (range 65 91)))
+(defn- generate-name []
   (str (apply str (take 2 (shuffle letters)))
        (+ 100 (.nextInt random 899))))
 
+(defn robot []
+  {:name (atom (generate-name))})
+
 (defn robot-name [robot]
-  (let [n @(:name robot)]
-    (if (= "" n)
-        (swap! (:name robot) #(str %1 (generate-name)))
-        n)))
+  @(:name robot))
 
 (defn reset-name [robot]
-  (swap! (:name robot) (fn [_] "")))
+  (reset! (:name robot) (generate-name)))


### PR DESCRIPTION
The original implementation seemed overly-complicated to me. This changes the example so that you generate the name when you generate the robot, rather than when you ask for its name.