### PR TITLE
Add clojure test generator and clock exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 tmp
 bin/configlet
 bin/configlet.exe
+x-common
 
 pom.xml
 pom.xml.asc

--- a/_src/clock_generator.clj
+++ b/_src/clock_generator.clj
@@ -1,0 +1,5 @@
+(ns clock-generator)
+
+(defn munge-data
+  [test-data]
+  test-data)

--- a/_src/generator.clj
+++ b/_src/generator.clj
@@ -1,0 +1,72 @@
+(ns generator
+  (:require [cheshire.core :as json]
+            [clojure.java.shell :refer [sh]]
+            [clojure.java.io :refer [reader]]
+            [stencil.core :as stencil])
+  (:import (java.io File IOException)))
+
+(defn file-exists?
+  "Helper function to determine if a given file exists."
+  [path]
+  (.exists (File. path)))
+
+(defn warn-and-exit
+  "Wrapper function to warn with the given message and then exit with a non-zero return"
+  [message]
+  (println message)
+  (System/exit 1))
+
+(defn clone-test-data
+  "Clone the x-common repo from github"
+  []
+  (sh "git" "clone" "git@github.com:exercism/x-common"))
+
+(defn load-test-data
+  "Clones and loads the test data for the given exercise"
+  [exercise-name]
+  (when-not (file-exists? "x-common")
+    (clone-test-data))
+  (let [test-data-filename (format "x-common/exercises/%s/canonical-data.json" exercise-name)]
+    (when-not (file-exists? test-data-filename)
+      (warn-and-exit
+       (format "Could not find test data for %s (looking in %s)"
+               exercise-name test-data-filename)))
+    (json/parse-stream (reader test-data-filename))))
+
+(defn munge-test-data
+  "Loads the generator namespace for the exercise and calls the munge-data function on the given test-data."
+  [exercise-name test-data]
+  (let [exercise-ns (symbol (str exercise-name "-generator"))]
+    (try
+      (require [exercise-ns])
+      (if-let [munge-data-fn (ns-resolve exercise-ns (symbol "munge-data"))]
+        (munge-data-fn test-data)
+        (do
+          (println (format "No munge-data function defined in %s" exercise-ns))
+          (println (format "Skipping any munging of canonical-data for %s" exercise-name))
+          test-data))
+      (catch IOException e
+        (println (format "Could not require %s due to an exception:\n\t%s" exercise-ns (.getMessage e)))
+        (println (format "Skipping any munging of canonical-data for %s" exercise-name))
+        test-data))))
+
+(defn generate-test-data
+  "Munges the test-data and renders the test for the exercise using the test template."
+  [exercise-name test-template-path test-data]
+  (let [munged-test-data (munge-test-data exercise-name test-data)
+        template (slurp test-template-path)]
+    (spit
+     (format "exercises/%s/test/%s_test.clj" exercise-name exercise-name)
+     (stencil/render-string template munged-test-data))))
+
+(defn -main
+  "Uses the test template for the exercise and test data to generate test cases."
+  [exercise-name & args]
+  (let [test-template-path (format "exercises/%s/%s.mustache" exercise-name exercise-name)
+        test-data (load-test-data exercise-name)]
+    (if (file-exists? test-template-path)
+      (do
+        (generate-test-data exercise-name test-template-path test-data)
+        (println (format "Generated tests for %s exercise using template %s" exercise-name test-template-path)))
+      (warn-and-exit (format "No exercise test template found at '%s'" test-template-path))))
+  (shutdown-agents))

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
 
   ],
   "ignored": [
+    "_src",
     "_test",
     "docs",
     "target",

--- a/config.json
+++ b/config.json
@@ -63,6 +63,11 @@
     },
     {
       "difficulty": 1,
+      "slug": "clock",
+      "topics": []
+    },
+    {
+      "difficulty": 1,
       "slug": "grade-school",
       "topics": []
     },

--- a/exercises/clock/clock.mustache
+++ b/exercises/clock/clock.mustache
@@ -1,0 +1,34 @@
+(ns clock-test
+  (:require [clock :refer :all]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest create-clock-test
+{{#create}}
+  {{#cases}}
+
+  (testing "{{{description}}}"
+    (let [test-clock (clock->string (clock {{{hour}}} {{{minute}}}))]
+      (is (= test-clock "{{{expected}}}")))){{/cases}}{{/create}})
+
+(deftest add-time-test
+{{#add}}
+  {{#cases}}
+
+  (testing "{{{description}}}"
+    (let [test-clock (clock->string (add-time (clock {{{hour}}} {{{minute}}}) {{{add}}}))]
+      (is (= test-clock "{{{expected}}}")))){{/cases}}{{/add}})
+
+(deftest equal-clock-test
+{{#equal}}
+  {{#cases}}
+  (testing "{{{description}}}"
+    (let [{{#clock1}}clock1 (clock {{{hour}}} {{{minute}}}){{/clock1}}
+          {{#clock2}}clock2 (clock {{{hour}}} {{{minute}}}){{/clock2}}]
+      {{#expected}}
+      (is (= clock1 clock2))))
+      {{/expected}}
+      {{^expected}}
+      (is (not= clock1 clock2))))
+      {{/expected}}
+    {{/cases}}
+{{/equal}})

--- a/exercises/clock/project.clj
+++ b/exercises/clock/project.clj
@@ -1,0 +1,4 @@
+(defproject clock "0.1.0-SNAPSHOT"
+  :description "clock exercise."
+  :url "https://github.com/exercism/xclojure/tree/master/exercises/clock"
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/exercises/clock/src/example.clj
+++ b/exercises/clock/src/example.clj
@@ -1,0 +1,19 @@
+(ns clock)
+
+(defn clock
+  "Return a 24 hour clock representation of the given hours and minutes."
+  [in-hour in-minute]
+  (let [total-minutes (mod (+ (* in-hour 60) in-minute) (* 60 24))
+        hours (mod (quot total-minutes 60) 24)
+        minutes (mod total-minutes 60)]
+    {:hour hours :minute minutes}))
+
+(defn clock->string
+  "Print the HH:MM representation of a clock."
+  [in-clock]
+  (format "%02d:%02d" (:hour in-clock) (:minute in-clock)))
+
+(defn add-time
+  "Add minutes to the given clock."
+  [in-clock minutes-to-add]
+  (clock (:hour in-clock) (+ (:minute in-clock) minutes-to-add)))

--- a/exercises/clock/test/clock_test.clj
+++ b/exercises/clock/test/clock_test.clj
@@ -1,0 +1,177 @@
+(ns clock-test
+  (:require [clock :refer :all]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest create-clock-test
+
+  (testing "on the hour"
+    (let [test-clock (clock->string (clock 8 0))]
+      (is (= test-clock "08:00"))))
+  (testing "past the hour"
+    (let [test-clock (clock->string (clock 11 9))]
+      (is (= test-clock "11:09"))))
+  (testing "midnight is zero hours"
+    (let [test-clock (clock->string (clock 24 0))]
+      (is (= test-clock "00:00"))))
+  (testing "hour rolls over"
+    (let [test-clock (clock->string (clock 25 0))]
+      (is (= test-clock "01:00"))))
+  (testing "hour rolls over continuously"
+    (let [test-clock (clock->string (clock 100 0))]
+      (is (= test-clock "04:00"))))
+  (testing "sixty minutes is next hour"
+    (let [test-clock (clock->string (clock 1 60))]
+      (is (= test-clock "02:00"))))
+  (testing "minutes roll over"
+    (let [test-clock (clock->string (clock 0 160))]
+      (is (= test-clock "02:40"))))
+  (testing "minutes roll over continuously"
+    (let [test-clock (clock->string (clock 0 1723))]
+      (is (= test-clock "04:43"))))
+  (testing "hour and minutes roll over"
+    (let [test-clock (clock->string (clock 25 160))]
+      (is (= test-clock "03:40"))))
+  (testing "hour and minutes roll over continuously"
+    (let [test-clock (clock->string (clock 201 3001))]
+      (is (= test-clock "11:01"))))
+  (testing "hour and minutes roll over to exactly midnight"
+    (let [test-clock (clock->string (clock 72 8640))]
+      (is (= test-clock "00:00"))))
+  (testing "negative hour"
+    (let [test-clock (clock->string (clock -1 15))]
+      (is (= test-clock "23:15"))))
+  (testing "negative hour rolls over"
+    (let [test-clock (clock->string (clock -25 0))]
+      (is (= test-clock "23:00"))))
+  (testing "negative hour rolls over continuously"
+    (let [test-clock (clock->string (clock -91 0))]
+      (is (= test-clock "05:00"))))
+  (testing "negative minutes"
+    (let [test-clock (clock->string (clock 1 -40))]
+      (is (= test-clock "00:20"))))
+  (testing "negative minutes roll over"
+    (let [test-clock (clock->string (clock 1 -160))]
+      (is (= test-clock "22:20"))))
+  (testing "negative minutes roll over continuously"
+    (let [test-clock (clock->string (clock 1 -4820))]
+      (is (= test-clock "16:40"))))
+  (testing "negative hour and minutes both roll over"
+    (let [test-clock (clock->string (clock -25 -160))]
+      (is (= test-clock "20:20"))))
+  (testing "negative hour and minutes both roll over continuously"
+    (let [test-clock (clock->string (clock -121 -5810))]
+      (is (= test-clock "22:10")))))
+
+(deftest add-time-test
+
+  (testing "add minutes"
+    (let [test-clock (clock->string (add-time (clock 10 0) 3))]
+      (is (= test-clock "10:03"))))
+  (testing "add no minutes"
+    (let [test-clock (clock->string (add-time (clock 6 41) 0))]
+      (is (= test-clock "06:41"))))
+  (testing "add to next hour"
+    (let [test-clock (clock->string (add-time (clock 0 45) 40))]
+      (is (= test-clock "01:25"))))
+  (testing "add more than one hour"
+    (let [test-clock (clock->string (add-time (clock 10 0) 61))]
+      (is (= test-clock "11:01"))))
+  (testing "add more than two hours with carry"
+    (let [test-clock (clock->string (add-time (clock 0 45) 160))]
+      (is (= test-clock "03:25"))))
+  (testing "add across midnight"
+    (let [test-clock (clock->string (add-time (clock 23 59) 2))]
+      (is (= test-clock "00:01"))))
+  (testing "add more than one day (1500 min = 25 hrs)"
+    (let [test-clock (clock->string (add-time (clock 5 32) 1500))]
+      (is (= test-clock "06:32"))))
+  (testing "add more than two days"
+    (let [test-clock (clock->string (add-time (clock 1 1) 3500))]
+      (is (= test-clock "11:21"))))
+  (testing "subtract minutes"
+    (let [test-clock (clock->string (add-time (clock 10 3) -3))]
+      (is (= test-clock "10:00"))))
+  (testing "subtract to previous hour"
+    (let [test-clock (clock->string (add-time (clock 10 3) -30))]
+      (is (= test-clock "09:33"))))
+  (testing "subtract more than an hour"
+    (let [test-clock (clock->string (add-time (clock 10 3) -70))]
+      (is (= test-clock "08:53"))))
+  (testing "subtract across midnight"
+    (let [test-clock (clock->string (add-time (clock 0 3) -4))]
+      (is (= test-clock "23:59"))))
+  (testing "subtract more than two hours"
+    (let [test-clock (clock->string (add-time (clock 0 0) -160))]
+      (is (= test-clock "21:20"))))
+  (testing "subtract more than two hours with borrow"
+    (let [test-clock (clock->string (add-time (clock 6 15) -160))]
+      (is (= test-clock "03:35"))))
+  (testing "subtract more than one day (1500 min = 25 hrs)"
+    (let [test-clock (clock->string (add-time (clock 5 32) -1500))]
+      (is (= test-clock "04:32"))))
+  (testing "subtract more than two days"
+    (let [test-clock (clock->string (add-time (clock 2 20) -3000))]
+      (is (= test-clock "00:20")))))
+
+(deftest equal-clock-test
+  (testing "clocks with same time"
+    (let [clock1 (clock 15 37)
+          clock2 (clock 15 37)]
+      (is (= clock1 clock2))))
+  (testing "clocks a minute apart"
+    (let [clock1 (clock 15 36)
+          clock2 (clock 15 37)]
+      (is (not= clock1 clock2))))
+  (testing "clocks an hour apart"
+    (let [clock1 (clock 14 37)
+          clock2 (clock 15 37)]
+      (is (not= clock1 clock2))))
+  (testing "clocks with hour overflow"
+    (let [clock1 (clock 10 37)
+          clock2 (clock 34 37)]
+      (is (= clock1 clock2))))
+  (testing "clocks with hour overflow by several days"
+    (let [clock1 (clock 3 11)
+          clock2 (clock 99 11)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative hour"
+    (let [clock1 (clock 22 40)
+          clock2 (clock -2 40)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative hour that wraps"
+    (let [clock1 (clock 17 3)
+          clock2 (clock -31 3)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative hour that wraps multiple times"
+    (let [clock1 (clock 13 49)
+          clock2 (clock -83 49)]
+      (is (= clock1 clock2))))
+  (testing "clocks with minute overflow"
+    (let [clock1 (clock 0 1)
+          clock2 (clock 0 1441)]
+      (is (= clock1 clock2))))
+  (testing "clocks with minute overflow by several days"
+    (let [clock1 (clock 2 2)
+          clock2 (clock 2 4322)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative minute"
+    (let [clock1 (clock 2 40)
+          clock2 (clock 3 -20)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative minute that wraps"
+    (let [clock1 (clock 4 10)
+          clock2 (clock 5 -1490)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative minute that wraps multiple times"
+    (let [clock1 (clock 6 15)
+          clock2 (clock 6 -4305)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative hours and minutes"
+    (let [clock1 (clock 7 32)
+          clock2 (clock -12 -268)]
+      (is (= clock1 clock2))))
+  (testing "clocks with negative hours and minutes that wrap"
+    (let [clock1 (clock 18 7)
+          clock2 (clock -54 -11513)]
+      (is (= clock1 clock2))))
+)

--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,8 @@
   :description  "Exercism Exercises in Clojure"
   :url          "https://github.com/exercism/xclojure"
   :test-paths   ["_test"]
+  :source-paths ["_src"]
+  :aliases {"generate" ["run" "-m" "generator"]}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [cheshire            "5.5.0"]])
+                 [cheshire            "5.5.0"]
+                 [stencil             "0.5.0"]])


### PR DESCRIPTION
This commit adds a generator namespace, adds a stencil dependency, and
adds x-common to the .gitignore. When invoked, this will clone the
x-common repo if not present, then load and munge any test-data for the
passed exercise, and then render clojure tests using a mustache template
for the exercise.