### PR TITLE
Simplify generate-name function for robot-name

### DIFF
--- a/exercises/robot-name/src/example.clj
+++ b/exercises/robot-name/src/example.clj
@@ -2,7 +2,7 @@
 
 (def ^:private letters (map char (range 65 91)))
 (defn- generate-name []
-  (format "%s%03d" (apply str (repeatedly 2 #(first (shuffle letters))))
+  (format "%s%03d" (apply str (repeatedly 2 #(rand-nth letters)))
           (rand-int 1000)))
 
 (defn robot []

--- a/exercises/robot-name/src/example.clj
+++ b/exercises/robot-name/src/example.clj
@@ -1,10 +1,9 @@
 (ns robot-name)
 
-(def ^:private random (java.util.Random.))
 (def ^:private letters (map char (range 65 91)))
 (defn- generate-name []
-  (str (apply str (take 2 (shuffle letters)))
-       (+ 100 (.nextInt random 899))))
+  (format "%s%03d" (apply str (repeatedly 2 #(first (shuffle letters))))
+          (rand-int 1000)))
 
 (defn robot []
   (atom {:name (generate-name)}))


### PR DESCRIPTION
This commit updates the generate-name function in robot-name to use
clojure's rand-int function instead of java interop. It also updates the
rand-int call to include all of the range 0-999 and refactors the string
assembly somewhat.